### PR TITLE
add Dockerfile and tooling to easily build and run the project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:13-alpine AS builder
+
+RUN apk add --no-cache make python git g++ util-linux
+
+WORKDIR /pomoday
+
+COPY package.json .
+
+RUN npm install
+
+COPY . .
+
+RUN npm run dist
+
+FROM halverneus/static-file-server:v1.7.0
+
+ENV PORT 8888
+
+COPY --from=builder /pomoday/dist /web

--- a/README.md
+++ b/README.md
@@ -81,6 +81,15 @@ To run it locally during development, use:
 npm run dev
 ```
 
+## Docker
+
+This repo includes a `Dockerfile` and a `docker-compose.yml` to easily run the project in a container. Just run the following two commands to build the container image and start it up:
+
+```
+docker-compose build
+docker-compose up -d
+```
+
 ## Similar Projects
 
 - [taskbook](https://github.com/klaussinani/taskbook): This is an awesome task management application that actually works, and works very well for everyone who likes to live in a command line. Pomoday was also heavily inspired by Taskbook, as you can see from the UI and the keyboard-only command interfaces.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.5'
+services:
+  pomoday:
+    build: ./
+    image: pomoday
+    restart: unless-stopped
+    ports:
+      - "8888:8888"


### PR DESCRIPTION
Hi @huytd,

with this PR users can now easily run the project in a container. The Dockerfile is a multistage build which means the resulting image is quite small since it does not include any build time dependencies.

Through the compose file both building and running is really simple. I have added instructions to the readme.

Fixes #2 

Future improvements:
- automatically build Dockerfile and push it to a registry
- once there is a release tag in this repo
  - also tag the image in the registry
  - add a Dockerfile.release which does not build the project, but instead fetches a prebuild release 