### PR TITLE
Implement multiple param commands

### DIFF
--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -92,11 +92,13 @@ export const InputBox = props => {
           ...state,
         };
         if (cmd) {
+          const ids = cmd.id ? cmd.id.match(/\d+/g).map(s => parseInt(s)) : null;
           switch (cmd.command.toLowerCase()) {
             case 'mv':
             case 'move':
+              const id = ids[0];
               tasksToUpdate = state.tasks.map(t => {
-                if (t.id === cmd.id) {
+                if (t.id === id) {
                   t.tag = cmd.tag;
                 }
                 return t;
@@ -105,7 +107,7 @@ export const InputBox = props => {
             case 'b':
             case 'begin':
               tasksToUpdate = state.tasks.map(t => {
-                if (t.id === cmd.id) {
+                if (ids.indexOf(t.id) !== -1) {
                   if (t.status !== TaskStatus.WIP) {
                     t.status = TaskStatus.WIP;
                     t.logs = (t.logs || []).concat({
@@ -120,7 +122,7 @@ export const InputBox = props => {
             case 'c':
             case 'check':
               tasksToUpdate = state.tasks.map(t => {
-                if (t.id === cmd.id) {
+                if (ids.indexOf(t.id) !== -1) {
                   t.status =
                     t.status === TaskStatus.DONE
                       ? TaskStatus.WAIT
@@ -135,31 +137,7 @@ export const InputBox = props => {
             case 'd':
             case 'delete':
               tasksToUpdate = state.tasks.reduce((tasks, t) => {
-                if (t.id !== cmd.id) {
-                  tasks.push(t);
-                }
-                return t;
-              });
-              break;
-            case 'c':
-            case 'check':
-              tasksToUpdate = state.tasks.map(t => {
-                if (t.id === cmd.id) {
-                  t.status =
-                    t.status === TaskStatus.DONE
-                      ? TaskStatus.WAIT
-                      : TaskStatus.DONE;
-                  if (t.status === TaskStatus.DONE) {
-                    t = stopWorkLogging(t);
-                  }
-                }
-                return t;
-              });
-              break;
-            case 'd':
-            case 'delete':
-              tasksToUpdate = state.tasks.reduce((tasks, t) => {
-                if (t.id !== cmd.id) {
+                if (ids.indexOf(t.id) === -1) {
                   tasks.push(t);
                 }
                 return tasks;
@@ -168,7 +146,7 @@ export const InputBox = props => {
             case 'fl':
             case 'flag':
               tasksToUpdate = state.tasks.map(t => {
-                if (t.id === cmd.id) {
+                if (ids.indexOf(t.id) !== -1) {
                   t.status =
                     t.status === TaskStatus.FLAG
                       ? TaskStatus.WAIT
@@ -181,7 +159,7 @@ export const InputBox = props => {
             case 'st':
             case 'stop':
               tasksToUpdate = state.tasks.map(t => {
-                if (t.id === cmd.id) {
+                if (ids.indexOf(t.id) !== -1) {
                   if (t.status === TaskStatus.WIP) {
                     t.status = TaskStatus.WAIT;
                     t = stopWorkLogging(t);
@@ -215,7 +193,7 @@ export const InputBox = props => {
             case 'e':
             case 'edit':
               {
-                const id = cmd.id;
+                const id = ids[0];
                 const task = cmd.text;
                 if (task && task.length) {
                   tasksToUpdate = state.tasks.map(t => {

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -96,9 +96,8 @@ export const InputBox = props => {
           switch (cmd.command.toLowerCase()) {
             case 'mv':
             case 'move':
-              const id = ids[0];
               tasksToUpdate = state.tasks.map(t => {
-                if (t.id === id) {
+                if (ids.indexOf(t.id) !== -1) {
                   t.tag = cmd.tag;
                 }
                 return t;

--- a/src/helpers/commands.ts
+++ b/src/helpers/commands.ts
@@ -9,7 +9,7 @@ const parseTaskCommand = (str: string) =>
   str.match(/^(t(?:ask)?)\s(@(?:\S*['-]?)(?:[0-9a-zA-Z'-]+))?(.*)/i);
 const parseEditCommand = (str: string) => str.match(/^(e(?:dit)?)\s(\d+)(.*)/i);
 const parseMoveCommand = (str: string) =>
-  str.match(/^(mv|move)\s(\d+)\s(@(?:\S*['-]?)(?:[0-9a-zA-Z'-]+))/i);
+  str.match(/^(mv|move)\s((?:\d+\s)+)(@(?:\S*['-]?)(?:[0-9a-zA-Z'-]+))/i);
 const parseCheckCommand = (str: string) => str.match(/^(c(?:heck)?)\s(.*)/i);
 const parseBeginCommand = (str: string) => str.match(/^(b(?:egin)?)\s(.*)/i);
 const parseDeleteCommand = (str: string) => str.match(/^(d(?:elete)?)\s(.*)/i);

--- a/src/helpers/commands.ts
+++ b/src/helpers/commands.ts
@@ -2,7 +2,7 @@ export type Command = {
   command: string;
   tag?: string;
   text?: string;
-  id?: number;
+  id?: string;
 } | null;
 
 const parseTaskCommand = (str: string) =>
@@ -10,11 +10,11 @@ const parseTaskCommand = (str: string) =>
 const parseEditCommand = (str: string) => str.match(/^(e(?:dit)?)\s(\d+)(.*)/i);
 const parseMoveCommand = (str: string) =>
   str.match(/^(mv|move)\s(\d+)\s(@(?:\S*['-]?)(?:[0-9a-zA-Z'-]+))/i);
-const parseCheckCommand = (str: string) => str.match(/^(c(?:heck)?)\s(\d+)/i);
-const parseBeginCommand = (str: string) => str.match(/^(b(?:egin)?)\s(\d+)/i);
-const parseDeleteCommand = (str: string) => str.match(/^(d(?:elete)?)\s(\d+)/i);
-const parseFlagCommand = (str: string) => str.match(/^(fl(?:ag)?)\s(\d+)/i);
-const parseStopCommand = (str: string) => str.match(/^(st(?:op)?)\s(\d+)/i);
+const parseCheckCommand = (str: string) => str.match(/^(c(?:heck)?)\s(.*)/i);
+const parseBeginCommand = (str: string) => str.match(/^(b(?:egin)?)\s(.*)/i);
+const parseDeleteCommand = (str: string) => str.match(/^(d(?:elete)?)\s(.*)/i);
+const parseFlagCommand = (str: string) => str.match(/^(fl(?:ag)?)\s(.*)/i);
+const parseStopCommand = (str: string) => str.match(/^(st(?:op)?)\s(.*)/i);
 const parseOtherCommand = (str: string) =>
   str.match(/^(close-help|help|today|dark|light)/i);
 
@@ -32,7 +32,7 @@ export const parseCommand = (input: string): Command => {
   if (matchEdit) {
     return {
       command: matchEdit[1],
-      id: parseInt(matchEdit[2]),
+      id: matchEdit[2],
       text: matchEdit[3].trim(),
     } as Command;
   }
@@ -41,7 +41,7 @@ export const parseCommand = (input: string): Command => {
   if (matchMove) {
     return {
       command: matchMove[1],
-      id: parseInt(matchMove[2]),
+      id: matchMove[2],
       tag: matchMove[3],
     } as Command;
   }
@@ -55,7 +55,7 @@ export const parseCommand = (input: string): Command => {
   if (matchOther) {
     return {
       command: matchOther[1],
-      id: parseInt(matchOther[2]),
+      id: matchOther[2],
     };
   }
 


### PR DESCRIPTION
This PR fixes #13 

![2019-11-02 14 27 55](https://user-images.githubusercontent.com/613943/68077207-051c7080-fd7d-11e9-93a7-a541359cfadd.gif)

From now, you can pass multiple ids to almost all commands (except edit command).

```js
b 1 2 3 // start task command
c 1 2 3 // mark them as done
d 1 2 3 // delete em' all
st 1 2 3 // stop em' all
fl 1 2 3 // flag em' all
mv 1 2 3 @new-tag // move a few tasks to a new tag
```