### PR TITLE
Implement tag rename feature

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -134,6 +134,8 @@ export const App = () => {
               <br />
               &nbsp; <b>st</b> or <b>stop</b>&nbsp;&nbsp; Stop working on a task
               <br />
+              &nbsp; <b>tr</b> or <b>tagre</b> or <b>tagrename</b> @tag-a @tag-b: Rename a tag
+              <br />
               &nbsp; <b>today</b>: Show today activities
               <br />
               &nbsp; <b>dark</b>: Enable dark mode
@@ -163,6 +165,8 @@ export const App = () => {
               &nbsp; <code>st 1</code> or <code>stop 1</code>
               <br />
               &nbsp; <code>edit 1 a new task description goes here</code>
+              <br />
+              &nbsp; <code>tr @work @play</code>
               <br />
               <br />
               Other commands:

--- a/src/components/InputBox.tsx
+++ b/src/components/InputBox.tsx
@@ -204,6 +204,19 @@ export const InputBox = props => {
                 }
               }
               break;
+            case 'tr':
+            case 'tagre':
+            case 'tagrename':
+              {
+                const [ from, to ] = cmd.tag.split(' ');
+                tasksToUpdate = state.tasks.map(t => {
+                  if (t.tag.match(from)) {
+                    t.tag = to;
+                  }
+                  return t;
+                });
+              }
+              break;
             case 'help':
               updateCandidate = {
                 ...updateCandidate,

--- a/src/helpers/commands.ts
+++ b/src/helpers/commands.ts
@@ -15,6 +15,8 @@ const parseBeginCommand = (str: string) => str.match(/^(b(?:egin)?)\s(.*)/i);
 const parseDeleteCommand = (str: string) => str.match(/^(d(?:elete)?)\s(.*)/i);
 const parseFlagCommand = (str: string) => str.match(/^(fl(?:ag)?)\s(.*)/i);
 const parseStopCommand = (str: string) => str.match(/^(st(?:op)?)\s(.*)/i);
+const parseTagRenameCommand = (str: string) =>
+  str.match(/^(tr|tagre|tagrename)\s(@(?:\S*['-]?)(?:[0-9a-zA-Z'-]+))\s(@(?:\S*['-]?)(?:[0-9a-zA-Z'-]+))/i);
 const parseOtherCommand = (str: string) =>
   str.match(/^(close-help|help|today|dark|light)/i);
 
@@ -43,6 +45,14 @@ export const parseCommand = (input: string): Command => {
       command: matchMove[1],
       id: matchMove[2],
       tag: matchMove[3],
+    } as Command;
+  }
+
+  const matchTagRe = parseTagRenameCommand(input);
+  if (matchTagRe) {
+    return {
+      command: matchTagRe[1],
+      tag: matchTagRe[2] + ' ' + matchTagRe[3],
     } as Command;
   }
 


### PR DESCRIPTION
Now you can rename a tag by using `tr` or `tagre` or `tagrename` command.

For example:

```
tagre @work @play
```

Closes #19 