### PR TITLE
Upgrade version of static-file-server docker container in Dockerfile to support Apple silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY . .
 
 RUN npm run dist
 
-FROM halverneus/static-file-server:v1.7.0
+FROM halverneus/static-file-server:v1.8.8
 
 ENV PORT 8888
 


### PR DESCRIPTION
Currently, we are using the [halverneus/static-file-server](https://hub.docker.com/r/halverneus/static-file-server) v1.7.0. It doesn't support native Apple silicon, see the picture below
<img width="433" alt="before" src="https://user-images.githubusercontent.com/105633986/195279202-d45ee38d-8694-47f7-89a0-6678d14c45ce.png">
To support the native Apple silicon we need to upgrade it to v1.8.8, and the result will be:
<img width="357" alt="after" src="https://user-images.githubusercontent.com/105633986/195278584-7e83c07b-14ef-49da-9310-faf9cc72a80b.png">
